### PR TITLE
Monkeypatch PandasArray class fix #20

### DIFF
--- a/elbow/dtypes/_json.py
+++ b/elbow/dtypes/_json.py
@@ -4,8 +4,8 @@ from typing import Any, Iterable, Optional, Union
 import numpy as np
 import pyarrow as pa
 from pandas.api.extensions import register_extension_dtype
-from pandas.core.arrays import PandasArray
 
+from ._pandas_array import PandasArray
 from .base import PaExtensionArray, PaExtensionScalar, PaExtensionType, PdExtensionDtype
 
 __all__ = [

--- a/elbow/dtypes/_ndarray.py
+++ b/elbow/dtypes/_ndarray.py
@@ -3,8 +3,8 @@ from typing import Any, Dict, Iterable, Optional, Union
 import numpy as np
 import pyarrow as pa
 from pandas.api.extensions import register_extension_dtype
-from pandas.core.arrays import PandasArray
 
+from ._pandas_array import PandasArray
 from .base import PaExtensionArray, PaExtensionScalar, PaExtensionType, PdExtensionDtype
 
 __all__ = [

--- a/elbow/dtypes/_pandas_array.py
+++ b/elbow/dtypes/_pandas_array.py
@@ -1,0 +1,13 @@
+"""Monkeypatch PandasArray class.
+
+Pandas 2.x renamed and moved the PandasArray class.
+"""
+
+try:
+    # Pandas >= 2.x
+    from pandas.arrays import NumpyExtensionArray as PandasArray
+except ImportError:
+    # Pandas < 2.0
+    from pandas.core.arrays import PandasArray
+
+__all__ = ["PandasArray"]

--- a/elbow/dtypes/_pickle.py
+++ b/elbow/dtypes/_pickle.py
@@ -4,8 +4,8 @@ from typing import Any, Iterable, Optional, Union
 import numpy as np
 import pyarrow as pa
 from pandas.api.extensions import register_extension_dtype
-from pandas.core.arrays import PandasArray
 
+from ._pandas_array import PandasArray
 from .base import PaExtensionArray, PaExtensionScalar, PaExtensionType, PdExtensionDtype
 
 __all__ = [


### PR DESCRIPTION
Pandas 2.x renamed and moved the `PandasArray` class.

This allows `elbow` to be used with `Pandas` >= 2.0 (current is 2.2).